### PR TITLE
Remove jsonp from ajax call to API

### DIFF
--- a/holidays.html
+++ b/holidays.html
@@ -215,7 +215,6 @@
       $( document ).ready(function() {
         $.ajax({
             url: "http://staging-denver-now-api.herokuapp.com/schedules",
-            dataType:"jsonp",
             success: function(data){
               console.log('Success getting data from server: ' + data);
               $('body').append(template(data));


### PR DESCRIPTION
The [API now supports CORS](https://github.com/codeforamerica/denver-schedules-api/pull/7) so passing `jsonp` is no longer necessary.
