### PR TITLE
removes extra space from email sign-up alerts

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -436,14 +436,9 @@ footer a:hover {
 
 
 /* ===== MODAL STYLES ===== */
-/*
-.subscribe-form input {
-	margin-left: 3em;
-	margin-right: 3em;
-}*/
-
 #popup-content {	margin-bottom: 2em; }
 .modal-footer > button 
+.alert-success > h3, .alert-danger > h3 { margin-top: 0; }
 
 /* ===== MEDIA QUERIES ===== */
 


### PR DESCRIPTION
@boonrs @drewrwilson 

Removes extra space before alert title in the email sign-up form. Example of the extra space below:
![screenshot 2014-07-08 15 25 20](https://cloud.githubusercontent.com/assets/6335546/3517495/28927878-06ef-11e4-9694-78b5720eb51c.png)
