### PR TITLE
changes example address to something in district 4

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,9 +41,9 @@
       <div class="row bigSearch-container hidden-print">
         <div class="form  col-lg-8 col-lg-offset-2" role="form">
           <div class="form-group col-xs-10">
-            <input id="address" type="search" class="form-control bigSearch-input" placeholder="e.g. 305 Milwaukee St">
+            <input id="address" type="search" class="form-control bigSearch-input" placeholder="e.g. 305 Milwaukee St, Denver, CO">
             <br />
-            or use an example: <a href="javascript:void(0)" onclick="defaultAddress()">305 Milwaukee St</a>
+            or use an example: <a href="javascript:void(0)" onclick="defaultAddress()">305 Milwaukee St, Denver, CO</a>
           </div>
           <button id="submit" type="submit" class="btn blue-btn bigSearch-submit col-xs-2">Find Address</button>
 
@@ -205,7 +205,7 @@
           </button>
         </div>
       </div>
-      
+
 
       </div> <!-- #ss-schedule -->
 

--- a/js/streetsweeping.js
+++ b/js/streetsweeping.js
@@ -38,7 +38,7 @@ Handlebars.registerHelper("formatNextDate", function(date) {
 
 
 function defaultAddress(){
-  $('#address').val('305 Milwaukee St');
+  $('#address').val('305 Milwaukee St, Denver, CO');
   $('#results').html('<div class="text-center"><img src="img/loading.gif" /></div>');
   $('#submit').click();
 }


### PR DESCRIPTION
Changed the example to '305 Milwaukee St' (the address for the Ross Cherry Creek Library in the ghost text, example text, and javascript. Turns out you don't need Denver, CO or Zip for it to work.
