### PR TITLE
appropriately capitalizes strings in table

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@
             {{#hasUpcoming}}
             <tr>
               <td>{{firstDate upcoming}}</td>
-              <td>{{name}}</td>
+              <td>{{toTitleCase name}}</td>
               <td>{{description}}</td>
               <td>TBD</td>
             </tr>

--- a/js/streetsweeping.js
+++ b/js/streetsweeping.js
@@ -1,6 +1,6 @@
 //this function outputs our custom way of abbreviating days
 Date.prototype.getDayAbbrev = function(){
-    var days = new Array("SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT");
+    var days = new Array("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat");
     return days[this.getDay()];
 }
 
@@ -16,9 +16,26 @@ Date.prototype.getMonthFull = function(){
 
 //this function outputs our custom way of abbreviating month names
 Date.prototype.getMonthAbbrev = function(){
-    var months = new Array("JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC");
+    var months = new Array("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec");
     return months[this.getMonth()];
 }
+
+
+/* 
+ *   This function converts a string to "Title Case"
+ *   Adapted from https://gist.github.com/LeoDutra/2764339
+*/
+String.prototype.toTitleCase = function(){
+  var str = this.toString();
+  
+  // \u00C0-\u00ff for a happy Latin-1
+  return str.toLowerCase().replace(/_/g, ' ').replace(/\b([a-z\u00C0-\u00ff])/g, function (_, initial) {
+      return initial.toUpperCase();
+  }).replace(/(\s(?:de|a|o|e|da|do|em|ou|[\u00C0-\u00ff]))\b/ig, function (_, match) {
+      return match.toLowerCase();
+  });
+};
+
 
 Handlebars.registerHelper("firstDate", function(array) {
   if(array && array.length > 0 ) {
@@ -35,6 +52,17 @@ Handlebars.registerHelper("formatNextDate", function(date) {
   date = new Date(date);
   return date.getDayFull() + ", " + date.getMonthFull() + " " + (date.getDate() +1);
 });
+
+Handlebars.registerHelper("toTitleCase", function(array) {
+  if(array && array.length > 0 ) {
+    return array.toTitleCase();
+  }
+  else {
+    return '';
+  }
+});
+
+
 
 
 function defaultAddress(){


### PR DESCRIPTION
- Changed strings in <code>getDayAbbrev</code> and <code>getMonthAbbrev</code> to Title Case:  <code>Array("JAN", "FEB", "MAR", "APR", "MAY"</code> to <code>Array("Jan", "Feb", "Mar", "Apr", "May"</code>
- Added a new Handlebars helper called "toTitleCase" which uses the function <code>toTitleCase()</code> to convert strings to ... wait for it ... title case. 

I adapted my code from https://gist.github.com/LeoDutra/2764339 which I referenced in a comment in the code.
