### PR TITLE
Display appropriate message for nightly street sweeping

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,7 +191,13 @@
             </tr>
             {{/hasUpcoming}}
             {{^hasUpcoming}}
-              {{error}}
+              <tr>
+              <td>Tonight</td>
+              <td>8am - 5pm</td>
+              <td>{{toTitleCase name}}</td>
+              <td>{{description}}</td>
+              <td>TBD</td>
+            </tr>
             {{/hasUpcoming}}
           {{/this}}
         </table>

--- a/js/streetsweeping.js
+++ b/js/streetsweeping.js
@@ -54,8 +54,12 @@ Handlebars.registerHelper("firstDate", function(array) {
 });
 
 Handlebars.registerHelper("formatNextDate", function(date) {
-  date = new Date(date);
-  return date.getDayFull() + ", " + date.getMonthFull() + " " + (date.getDate() +1);
+  if(date) {
+    date = new Date(date);
+    return date.getDayFull() + ", " + date.getMonthFull() + " " + (date.getDate() +1);
+  }
+  else
+    return "tonight";
 });
 
 Handlebars.registerHelper("toTitleCase", function(array) {


### PR DESCRIPTION
@codeforamerica/denver 
We're no longer handling nightly schedules. I made a pass at it, but think it will probably have some side effects. Notice how I threw away where the error message was being outputted. I don't think that part of the screen will display if there's an error.
